### PR TITLE
minor correction to board mode example

### DIFF
--- a/OpenBCI Software/04-OpenBCI_Cyton_SDK.md
+++ b/OpenBCI Software/04-OpenBCI_Cyton_SDK.md
@@ -442,7 +442,7 @@ First, user sends **//**
 
 **returns** `Board mode is default$$$`
 
-Then, user sends **~2**
+Then, user sends **/2**
 
 **returns** `Board mode set to analog$$$`
 


### PR DESCRIPTION
minor.  probably a copy and paste error.  ~2 should be /2 for board mode