### PR TITLE
Update OpenBCI GUI link

### DIFF
--- a/Headware/01-Ultracortex-Mark-IV.md
+++ b/Headware/01-Ultracortex-Mark-IV.md
@@ -466,7 +466,7 @@ Now that you have your Ultracortex assembled and comfortably adjusted to your he
 
 ![image](../assets//MarkIV/Photos/UCM4-Product-2.JPG)
 
-Check out the [Getting Started w/ OpenBCI tutorial](http://docs.openbci.com/OpenBCI%20Software/01-OpenBCI_GUI) to get up-and-running with the [OpenBCI Processing GUI](https://github.com/OpenBCI/OpenBCI_Processing).
+Check out the [Getting Started w/ OpenBCI tutorial](http://docs.openbci.com/OpenBCI%20Software/01-OpenBCI_GUI) to get up-and-running with the [OpenBCI GUI](https://github.com/OpenBCI/OpenBCI_GUI).
 
 Below is a screenshot of what the GUI looks like when you've got your OpenBCI + Ultracortex (w/ 8 channels) hooked up! You can see a nice alpha (~11 hz) spike on the FFT Plot. 
 


### PR DESCRIPTION
The existing link routes to the deprecated GUI