### PR TITLE
simplify FTDI instructions

### DIFF
--- a/OpenBCI Software/01-OpenBCI_GUI.md
+++ b/OpenBCI Software/01-OpenBCI_GUI.md
@@ -8,22 +8,6 @@ The OpenBCI GUI is OpenBCI's default software tool for visualizing, recording, a
 
 ## Hardware/Driver Setup for OpenBCI_GUI and OpenBCIHub
 
-### Cyton on macOS/Windows/Linux
-
-![FTDI Install](../assets/images/FTDI.png)
-
-The FTDI chip on your OpenBCI Dongle requires you to install the FTDI drivers on your machine. You may already have these installed, if you've worked with Arduino or other USB hardware accessories. You can download the latest FTDI drivers for your operating system [here](http://www.ftdichip.com/Drivers/VCP.htm). 
-
-**Windows 64-bit Users:** Here is a direct link to download the FTDI version for your system [here.](https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip)
-
-**Note:** if you jumped ahead and are already running your GUI, you may need to restart your GUI for this to take effect.
-
-![Unidentified Developer MAC](../assets/images/securityAndPrivacy.png)
-
-**Mac Users:** When you try to install the FTDI driver, your computer may tell you that it is unable to install the application because it is from an unidentified developer. In this case, go to System Preference > Security & Privacy and switch your settings to "Allow Applications Downloaded from: Anywhere," as seen in the screenshot to the right. You will most likely have to unlock the lock (and type in your root password) at the bottom of the Security & Privacy window before you can make this change.
-
-**Linux Users:** According to the FTDI website, Ubuntu comes with the necessary FTDI drivers! Just make sure you have permission to access the serial ports. See section "Fix Linux Serial Port Permissions" below.
-
 ### Ganglion on macOS
 Turn on your computer's Bluetooth if not already.
 

--- a/Tutorials/01-Cyton_Getting Started_Guide.md
+++ b/Tutorials/01-Cyton_Getting Started_Guide.md
@@ -59,11 +59,7 @@ Come back to this guide when your GUI is running!
 
 ## III. Prepare your OpenBCI Hardware
 
-### 1. Make sure your FTDI drivers are installed and up-to-date
-
-The Cyton will not work without the VCP drivers. Please see how to get and install the VCP driver in the prerequisites section in the [the step by step guide](http://docs.openbci.com/OpenBCI%20Software/01-OpenBCI_GUI)
-
-### 2. Plug in your OpenBCI USB Dongle
+### 1. Plug in your OpenBCI USB Dongle
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/dongleConnection.png?raw=true" width="70%">
 
@@ -71,13 +67,13 @@ Plug this in (facing upwards!) and you should see a blue LED light up.
 
 **Note:** make sure your USB Dongle is switched to GPIO 6 and not RESET. The switch should be set closer to your computer as seen in the picture to the right.
 
-### 3. Plug in your 6V AA battery pack (with batteries)
+### 2. Plug in your 6V AA battery pack (with batteries)
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/batteryConnection.png?raw=true" width="70%">
 
 Cyton boards have specific input voltage ranges. These input voltage ranges can be found on the back-side of the board, next to the power supply. **BE VERY CAREFUL** to not supply your board with voltages above these ranges, or else you will damage your board's power supply. For this reason, we recommend that you always use the battery pack that came with your OpenBCI kit. There's a good reason we put this notice in here twice!
 
-### 4. Switch your Cyton board to PC (not OFF or BLE)
+### 3. Switch your Cyton board to PC (not OFF or BLE)
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/PowerUpBoard.JPG?raw=true" width="70%">
 
@@ -88,23 +84,19 @@ Make sure to move the small switch on the right side of the board from "OFF" to 
 
 ## IV. Connect to your Cyton board from the GUI
 
-### 1. Relaunch your OpenBCI GUI
-
-You may need to relaunch the OpenBCI GUI after installing the FTDI drivers.
-
-### 2. Select LIVE (from Cyton)
+### 1. Select LIVE (from Cyton)
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/serial_cyton_select_cyton.png?raw=true" width="50%">
 
 In order to connect to your Cyton, you must specify the data source to be `LIVE (from Cyton)` in the first section of the System Control Panel. Before hitting the `START SYSTEM` button, you need to configure your Cyton board (follow the steps below).
 
-### 3. Select Serial Transfer Protocol
+### 2. Select Serial Transfer Protocol
 
 Next select `Serial (from Dongle)`. If you want to use the WiFi Shield, please see the [WiFi Getting Started Guide](http://docs.openbci.com/Tutorials/03-Wifi_Getting_Started_Guide#wifi-getting-started-guide-overview)
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/serial_cyton_select_serial.png?raw=true" width="50%">
 
-### 4. Find your USB Dongle's Serial/COM port
+### 3. Find your USB Dongle's Serial/COM port
 
 In the first section of the LIVE (from Cyton) sub-panel, find your Dongle's Serial/COM port name. If you're using a Mac or Linux, its name will be in the following format:
 
@@ -120,17 +112,16 @@ Your USB Dongle's port name will likely be at the top of the list. If you don't 
 
 1. Make sure your dongle is plugged in and switched to GPIO 6 (not RESET)
 2. Click the REFRESH LIST button in the SERIAL/COM PORT section of the sub-panel
-3. Make sure you've installed the latest FTDI drivers, as described in section III.1
 
 If you're still having trouble finding your USB Dongle's port name, refer to the [Forum](http://openbci.com/index.php/forum/) about debugging your hardware connection.
 
-### 5. Select your channel count (8 or 16)
+### 4. Select your channel count (8 or 16)
 
 <img src="https://github.com/OpenBCI/Docs/blob/master/assets/images/channelCount.png?raw=true" width="50%">
 
 The CHANNEL COUNT setting is defaulted to 8. If you are working with an OpenBCI Daisy Module and Cyton board (16-channel) system, be sure to click the 16 CHANNELS button before starting your system.
 
-### 6. Optional Settings
+### 5. Optional Settings
 
 <details><summary>If you're comfortable using the GUI, use the optional settings in this dropdown section. Otherwise, skip to step 7!</summary><br>
 

--- a/Tutorials/10-Mac_FTDI_Driver_Fix.md
+++ b/Tutorials/10-Mac_FTDI_Driver_Fix.md
@@ -2,7 +2,9 @@
 
 ### Summary
 
-If you've been working with OpenBCI on macOS, you may have noticed that the data coming from your board and into your computer is very choppy. This is a result of the FTDI virtual com port (VCP) driver's default settings for macOS. For more info on FTDI VCP drivers, see [this forum thread](http://openbci.com/forum/index.php?p=/discussion/196/os-x-and-virtual-com-ports-mavericks-yosemite-note) and the [FTDI VCP web page](http://www.ftdichip.com/Drivers/VCP.htm).
+On some Macs, you may have noticed that the data coming from your board is very choppy.
+
+This is a result of the FTDI virtual com port (VCP) driver's default settings for macOS. For more info on FTDI VCP drivers, see [this forum thread](http://openbci.com/forum/index.php?p=/discussion/196/os-x-and-virtual-com-ports-mavericks-yosemite-note) and the [FTDI VCP web page](http://www.ftdichip.com/Drivers/VCP.htm).
 
 This document details how to edit the config data of the **Info.plist** file of your FTDI VCP driver, so that the choppiness is significantly reduced, and you are able to process the data in real-time, with minimal latency!
 
@@ -12,6 +14,7 @@ This tutorial has been verified to work with the following macOS versions:
 - 10.10
 - 10.11
 - 10.13
+- 10.14
 
 ### Step 1: open Terminal
 
@@ -31,21 +34,14 @@ If you are new to Terminal, it is best to simply copy and paste the lines of cod
 
 ### Step 2: Remove any existing FTDI drivers & reboot
 
-Remove the FTDI [kernel extension](http://forums.macnn.com/79/developer-center/81624/what-is-a-kext-file/) (.kext) from your machine. You might not have it  installed already. If you do not, skip this step.
+Remove the FTDI [kernel extension](http://forums.macnn.com/79/developer-center/81624/what-is-a-kext-file/) (.kext) from your machine. You might not have it installed already. If you do not, skip this step.
 
 ```
-sudo rm -rf /System/Library/Extensions/FTDIUSBSerialDriver.kext
-```
-
-Also, make sure you do not have another older version of the FTDI Driver on your machine. For some reason version 2.2.18 installs itself in **/System/Libraries/Extensions**, whereas version 2.3 installs itself in **/Libraries/Extentions**, a different filepath altogether.
-
-If you find **FTDIUSBSerialDriver.kext** there as well, remove it with the following line of code:
-
-```
+sudo rm /System/Library/Extensions/FTDIUSBSerialDriver.kext
 sudo rm -rf /Library/Extensions/FTDIUSBSerialDriver.kext
 ```
 
-After removing all exisitng FTDI drivers, reboot your computer before continuing.
+After removing all exisitng FTDI drivers, reboot your computer.
 
 ### Step 3: get the FTDI driver
 
@@ -57,7 +53,7 @@ Here are the direct download links for [32-bit](http://www.ftdichip.com/drivers/
 
 The downloaded .dmg comes with two installers in it. **FTDIUSBSerialDriver_10_3** for OS X 10.3 and **FTDIUSBSerialDriver_10_4_10_5_10_6_10_7** for the rest. You most likely need to install **FTDIUSBSerialDriver_10_4_10_5_10_6_10_7**.
 
-#### for macOS 10.13
+#### for macOS 10.13 and 10.14
 
 Download and install the FTDI Driver 2.4.2 from the [FTDI VCP page](http://www.ftdichip.com/Drivers/VCP.htm).
 
@@ -105,7 +101,8 @@ If everthing is good, nothing should print after running this command.
 ```
 sudo emacs /System/Library/Extensions/FTDIUSBSerialDriver.kext/Contents/Info.plist
 ```
-**Note:** if you'd prefer to use vim (as opposed to emacs) as your text editor, go right ahead! To do so, use run the terminal command below, as opposed to the one above.
+
+or
 
 ```
 sudo vim /System/Library/Extensions/FTDIUSBSerialDriver.kext/Contents/Info.plist
@@ -173,7 +170,7 @@ Now add the new config data for the "FT X Series" as seen below. The "FT X Serie
 ```
 **Note:** We also rename the port name to OpenBCI because it's easier to spot if the board is connected or not.
 
-#### for macOS 10.13, using the driver 2.4.2
+#### for macOS 10.13 and 10.14, using the driver 2.4.2
 
 **BEFORE**
 
@@ -230,7 +227,6 @@ Now add the new config data for the "FT X Series" as seen below. The "FT X Serie
 </dict>
 ```
 
-
 ### Step 11: save & close
 
 In emacs:
@@ -268,19 +264,11 @@ You should get a response that looks something like this:
   145    0 0xffffff7f82dce000 0x8000     0x8000     com.FTDI.driver.FTDIUSBSerialDriver (2.2.18) <118 37 5 4 3 1>
 ```
 
-### Step 14: have fun with real time data
+### Step 14: enjoy smoother streaming
 
 Open the OpenBCI Processing GUI (or other software), connect to your device, and begin streaming the data.
 
-Check out the improved latency!
-
-```
-\m/-(^.^)-\m/
-```
-
-
 ------------
-
 
 ### Helpful Resources
 

--- a/Tutorials/11-OpenBCI_on_Windows.md
+++ b/Tutorials/11-OpenBCI_on_Windows.md
@@ -4,8 +4,6 @@ Tested on:
 - Windows 7
 - Windows XP
 
-## FTDI Drivers
-
 ### I. Connecting the Board
 
 ![Device Manager](../assets/images/device-man.jpg)


### PR DESCRIPTION
- [x] Remove mentions of installing FTDI drivers. All OSes include FTDI drivers that work out of the box. In almost every case, the user does not need to install FTDI drivers. In the Mac case, installing FTDI can make things worse. Some macs come with working FTDI drivers out of the box (that stream smoothly!). Only Mac users who are having issues should follow this tutorial.
- [x] Simplified and corrected the FTDI tutorial a little bit